### PR TITLE
qodana: fix workflow job needs

### DIFF
--- a/.github/workflows/dispatch-qodana.yml
+++ b/.github/workflows/dispatch-qodana.yml
@@ -43,7 +43,6 @@ jobs:
           client-payload: ${{ steps.client_payload.outputs.client_payload }}
 
   qodana:
-    needs: [initialize-notify]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -105,6 +104,7 @@ jobs:
       - name: Qodana
         id: qodana
         if: ${{ steps.rename.conclusion == 'success' }}
+        continue-on-error: true
         uses: JetBrains/qodana-action@v2022.3.4
         with:
           additional-cache-hash: ${{ github.event.client_payload.checkout_repo }}-${{ github.event.client_payload.checkout_ref }}-${{ github.event.client_payload.destination}}-${{ matrix.language }}  # yamllint disable-line rule:line-length
@@ -116,6 +116,7 @@ jobs:
       - name: Prepare gh-pages
         id: pages
         if: ${{ steps.qodana.conclusion != 'skipped' }}
+        continue-on-error: true
         run: |
           repo=${{ github.event.client_payload.github.event.repository.name }}
           destination=${{ github.event.client_payload.destination }}
@@ -134,6 +135,7 @@ jobs:
       - name: Deploy to gh-pages
         id: deploy
         if: ${{ steps.pages.conclusion == 'success' }}
+        continue-on-error: true
         uses: actions-js/push@v1.4
         with:
           github_token: ${{ secrets.GH_BOT_TOKEN }}
@@ -150,7 +152,7 @@ jobs:
 
   final-notify:
     name: Final Notify
-    needs: [qodana]
+    needs: [initialize-notify, qodana]
     if: ${{ startsWith(github.event.client_payload.github.event_name, 'pull_request') }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fixes an issue where qodana job would not run unless triggering event was a PR. Should also allow the final notify to run if there is a qodana failure, by adding `continue_on_error` statements.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
