### PR TITLE
qodana: no baseline for non pulls

### DIFF
--- a/.github/workflows/dispatch-qodana.yml
+++ b/.github/workflows/dispatch-qodana.yml
@@ -82,24 +82,33 @@ jobs:
       - name: Get baseline
         id: baseline
         run: |
-          sarif_file=qodana.sarif.json
-          repo=${{ github.event.client_payload.github.event.repository.name }}
-          target=${{ github.event.client_payload.target }}
-          language=${{ matrix.language }}
-
-          baseline_file="./gh-pages/${repo}/${target}/${language}/results/${sarif_file}"
-
-          # check if file exists
-          if [ -f ${baseline_file} ]
+          # check if destination is not an integer
+          if ! [[ "${{ github.event.client_payload.destination }}" =~ ^[0-9]+$ ]]
           then
+            echo "Running for a branch update"
+            echo "baseline_args=" >> $GITHUB_OUTPUT
+          else
+            echo "Running for a PR"
+
+            sarif_file=qodana.sarif.json
+            repo=${{ github.event.client_payload.github.event.repository.name }}
+            target=${{ github.event.client_payload.target }}
+            language=${{ matrix.language }}
+
+            baseline_file="./gh-pages/${repo}/${target}/${language}/results/${sarif_file}"
+
+            # check if file exists
+            if [ -f ${baseline_file} ]
+            then
               echo "baseline exists"
               echo "baseline_args=--baseline,qodana.sarif.json" >> $GITHUB_OUTPUT
 
               # copy the file
               cp -f ${baseline_file} ./${sarif_file}
-          else
+            else
               echo "baseline does not exist"
               echo "baseline_args=" >> $GITHUB_OUTPUT
+            fi
           fi
 
       - name: Rename Qodana config file


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR prevents Qodana from using baseline for branch pushes.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
